### PR TITLE
Changing the s.version from '1.0.0' to '2.0.0' so the iOS pod build s…

### DIFF
--- a/ios/ffmpeg_kit_flutter_new.podspec
+++ b/ios/ffmpeg_kit_flutter_new.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ffmpeg_kit_flutter_new'
-  s.version          = '1.0.0'
+  s.version          = '2.0.0'
   s.summary          = 'FFmpeg Kit for Flutter'
   s.description      = 'A Flutter plugin for running FFmpeg and FFprobe commands.'
   s.homepage         = 'https://github.com/sk3llo/ffmpeg_kit_flutter'


### PR DESCRIPTION
…hows the correct version.

I have changed the version of the package from '1.0.0' to '2.0.0' in the s.version inside 'iOS/ffmpeg_kit_flutter_new.podspec'. This will make the pod install process shows(and pulls) the correct version of the package.