### PR TITLE
Android ProGuard comsumer rules for FFmpegKitConfig and AbiDetect

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,6 +47,7 @@ android {
         minSdk = 24
         versionCode 1
         versionName "1.0.0"
+        consumerProguardFiles 'consumer-rules.pro'
     }
 
     dependencies {

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,11 @@
+-keep class com.antonkarpenko.ffmpegkit.FFmpegKitConfig {
+    native <methods>;
+    void log(long, int, byte[]);
+    void statistics(long, int, float, float, long , double, double, double);
+    int safOpen(int);
+    int safClose(int);
+}
+
+-keep class com.antonkarpenko.ffmpegkit.AbiDetect {
+    native <methods>;
+}


### PR DESCRIPTION
Closes: #129

I copied the ProGuard consumer rules from the original ffmpeg-kit package found [here](https://github.com/arthenica/ffmpeg-kit/blob/main/android/ffmpeg-kit-android-lib/consumer-rules.pro) and changed the rdns from `com.arthenica.ffmpegkit` to `com.antonkarpenko.ffmpegkit`
