### PR TITLE
docs: Add macOS Homebrew dependencies requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ dependencies:
 ```
 
 
+### macOS Development Requirements
+
+**Note for macOS Developers (arm64/Apple Silicon):**
+The pre-compiled FFmpeg frameworks for macOS require certain Homebrew libraries to be installed on your development machine. If you encounter dyld errors about missing libraries, install the following:
+
+```bash
+brew install libiconv libsamplerate srt
+```
+
+This is a known limitation with the current pre-built frameworks. For more details, see issue #134.
+
 ### 3. Packages
 
 There are eight different `ffmpeg-kit` packages:


### PR DESCRIPTION
This PR adds a section to the README.md documenting the macOS Homebrew dependencies requirement for arm64/Apple Silicon developers.

As discussed in issue #134, the pre-compiled FFmpeg frameworks for macOS have hardcoded Homebrew paths, which causes dyld errors on machines without these libraries. This documentation provides a workaround for developers until a permanent fix is implemented.

Ref: #134