### PR TITLE
fix: convert iOS frameworks to XCFrameworks for iOS 26+ simulator arm64 support

### DIFF
--- a/ios/ffmpeg_kit_flutter_new.podspec
+++ b/ios/ffmpeg_kit_flutter_new.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.default_subspec = 'full-gpl'
 
   s.dependency          'Flutter'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386 arm64' }
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
 
   s.subspec 'full-gpl' do |ss|
     # Adding pre-install hook
@@ -30,14 +30,14 @@ Pod::Spec.new do |s|
     CMD
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.ios.vendored_frameworks = 'Frameworks/ffmpegkit.framework',
-                                 'Frameworks/libavcodec.framework',
-                                 'Frameworks/libavdevice.framework',
-                                 'Frameworks/libavfilter.framework',
-                                 'Frameworks/libavformat.framework',
-                                 'Frameworks/libavutil.framework',
-                                 'Frameworks/libswresample.framework',
-                                 'Frameworks/libswscale.framework'
+    ss.ios.vendored_frameworks = 'Frameworks/ffmpegkit.xcframework',
+                                 'Frameworks/libavcodec.xcframework',
+                                 'Frameworks/libavdevice.xcframework',
+                                 'Frameworks/libavfilter.xcframework',
+                                 'Frameworks/libavformat.xcframework',
+                                 'Frameworks/libavutil.xcframework',
+                                 'Frameworks/libswresample.xcframework',
+                                 'Frameworks/libswscale.xcframework'
     ss.ios.frameworks = 'AudioToolbox', 'CoreMedia'
     ss.libraries = 'z', 'bz2', 'c++', 'iconv'
     ss.ios.deployment_target = '14.0'

--- a/scripts/setup_ios.sh
+++ b/scripts/setup_ios.sh
@@ -16,3 +16,56 @@ xcrun bitcode_strip -r Frameworks/libavformat.framework/libavformat -o Framework
 xcrun bitcode_strip -r Frameworks/libavutil.framework/libavutil -o Frameworks/libavutil.framework/libavutil
 xcrun bitcode_strip -r Frameworks/libswresample.framework/libswresample -o Frameworks/libswresample.framework/libswresample
 xcrun bitcode_strip -r Frameworks/libswscale.framework/libswscale -o Frameworks/libswscale.framework/libswscale
+
+# Convert each framework to XCFramework with device + simulator variants
+# iOS 26+ simulators on Apple Silicon require arm64, but the vendored
+# frameworks ship arm64 built for iOS device platform, not simulator.
+# Xcode rejects linking device binaries into simulator targets.
+# Fix: create .xcframework with two variants — device unchanged,
+# simulator variant has arm64 platform patched to IOSSIMULATOR.
+for fw in Frameworks/*.framework; do
+  fwname=$(basename "$fw" .framework)
+  fwpath="$fw/$fwname"
+
+  # Thin fat binary into per-architecture slices
+  lipo "$fwpath" -thin arm64  -output "/tmp/${fwname}_arm64"
+  lipo "$fwpath" -thin x86_64 -output "/tmp/${fwname}_x86_64"
+  lipo "$fwpath" -thin arm64e -output "/tmp/${fwname}_arm64e"
+
+  # Convert arm64 slice from IOS (platform 2) to IOSSIMULATOR (platform 7)
+  # Keeps minos=12.1 and sdk=18.5 to match original build
+  xcrun vtool -set-build-version 7 12.1 18.5 -replace \
+    -output "/tmp/${fwname}_arm64_sim" "/tmp/${fwname}_arm64"
+
+  # Device variant: keep arm64 (IOS) + arm64e (IOS) slices
+  devdir="XCFramework/tmp/ios-arm64/$fwname.framework"
+  mkdir -p "$devdir"
+  cp -R "$fw/" "$devdir/"
+  if [ -f "/tmp/${fwname}_arm64e" ]; then
+    lipo "/tmp/${fwname}_arm64" "/tmp/${fwname}_arm64e" \
+      -create -output "$devdir/$fwname"
+  else
+    cp "/tmp/${fwname}_arm64" "$devdir/$fwname"
+  fi
+
+  # Simulator variant: combined converted arm64 (IOSSIMULATOR) + original x86_64 (IOSSIMULATOR)
+  simdir="XCFramework/tmp/ios-arm64_x86_64-simulator/$fwname.framework"
+  mkdir -p "$simdir"
+  cp -R "$fw/" "$simdir/"
+  lipo "/tmp/${fwname}_arm64_sim" "/tmp/${fwname}_x86_64" \
+    -create -output "$simdir/$fwname"
+  # Info.plist must declare iPhoneSimulator platform for simulator variant
+  sed -i '' 's/iPhoneOS/iPhoneSimulator/g' "$simdir/Info.plist"
+
+  # Create final .xcframework containing both variants
+  xcodebuild -create-xcframework \
+    -framework "$devdir" \
+    -framework "$simdir" \
+    -output "Frameworks/$fwname.xcframework" 2>&1
+
+  rm -f "/tmp/${fwname}_arm64" "/tmp/${fwname}_arm64e" \
+        "/tmp/${fwname}_x86_64" "/tmp/${fwname}_arm64_sim"
+  rm -rf "XCFramework/tmp"
+done
+# Remove original .framework dirs, keep only .xcframework
+rm -rf Frameworks/*.framework


### PR DESCRIPTION
## Summary

iOS 26+ simulators on Apple Silicon require arm64 architecture. The vendored ffmpeg frameworks (`ffmpegkit.framework`, `libavcodec.framework`, etc.) had their arm64 slice built for iOS device platform, not iOS Simulator. Xcode rejected linking them with:

> Building for 'iOS-simulator', but linking in dylib built for 'iOS'

## Changes

### `scripts/setup_ios.sh`
After downloading and stripping bitcode, each `.framework` is converted to an `.xcframework` with two variants:

- **`ios-arm64_arm64e`** — device variant, original arm64 + arm64e slices unchanged (platform IOS)
- **`ios-arm64_x86_64-simulator`** — simulator variant, arm64 slice platform converted from IOS to IOSSIMULATOR via `vtool -set-build-version`, combined with the pre-existing x86_64 slice (already IOSSIMULATOR)

Headers and Modules directories are preserved in both variants.

### `ios/ffmpeg_kit_flutter_new.podspec`
- Updated `vendored_frameworks` to point to `.xcframework` files
- Removed `arm64` from `EXCLUDED_ARCHS[sdk=iphonesimulator*]` (only `i386` remains) — no longer needed since XCFramework provides correct per-platform slices

## Testing
- iPhone 17 Pro simulator (iOS 26.4) — app builds, links, and runs successfully
- iPhone 16 physical device (iOS 26.4.1) — app builds, links, and runs successfully

## Backward Compatibility
- Device builds: arm64 slice unchanged, linking works as before
- Intel Mac simulators: x86_64 slice unchanged, linking works as before
- Apple Silicon simulators (iOS 26+): arm64 slice now marked as IOSSIMULATOR, linking works
